### PR TITLE
Harden CI with dependency policy and audit checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
         target: [x86_64, aarch64]
         command: [build]
         include:
-          - args: --release --out dist -i 3.10 3.13t 3.14t
+          - args: --release --out dist -i 3.10 3.14t
           - command: sdist
             os:
               runner: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,20 +27,25 @@ env:
   KNOPE_VERSION: 0.22.4
 
 jobs:
-  # Should run on every push and PR
-  test:
-    name: Test
+  rust:
+    name: Rust
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Cargo build
         run: cargo build --workspace --verbose --locked
       - name: Cargo test
-        run: cargo test --workspace --verbose
+        run: cargo test --workspace --verbose --locked
       - name: Cargo fmt
         run: cargo fmt --all --check
       - name: Cargo clippy
-        run: cargo clippy --workspace --all-targets -- -D warnings
+        run: cargo clippy --workspace --all-targets --locked -- -D warnings
+
+  python:
+    name: Python
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -65,12 +70,38 @@ jobs:
         run: uv run basedpyright
       - name: Stubtest
         run: uv run task stubtest
-      - name: Check cargo dependencies
+
+  dependency-policy:
+    name: Dependency policy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Check licenses, bans, and sources
         uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2.0.20
+        with:
+          command: check bans licenses sources
+          arguments: --all-features --locked
+
+  dependency-review:
+    name: Dependency review
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Review dependency changes
+        if: github.event_name == 'pull_request'
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        with:
+          fail-on-severity: high
+          allow-licenses: MIT, Apache-2.0, Unicode-3.0, BSD-2-Clause, Zlib
+      - name: Skip dependency review outside pull requests
+        if: github.event_name != 'pull_request'
+        run: echo "Dependency review only applies to pull requests."
 
   build:
     runs-on: ${{ matrix.os.runner }}
-    needs: test
     strategy:
       matrix:
         os:
@@ -108,7 +139,10 @@ jobs:
   check:
     if: always()
     needs:
-      - test
+      - rust
+      - python
+      - dependency-policy
+      - dependency-review
       - build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,33 @@
+name: Dependency audit
+
+on:
+  schedule:
+    - cron: "17 2 * * *"
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - Cargo.lock
+      - Cargo.toml
+      - bosing-py/Cargo.toml
+      - deny.toml
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  rustsec:
+    name: RustSec advisories
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Check RustSec advisories
+        uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2.0.20
+        with:
+          command: check advisories
+          arguments: --all-features --locked

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "autocfg"
@@ -162,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/python/tests/test_basic.py
+++ b/python/tests/test_basic.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 import numpy as np
 import numpy.typing as npt
 from rich.pretty import pretty_repr
@@ -41,7 +43,7 @@ def test_basic() -> None:
     assert "xy0" in result
     w = result["xy0"]
     assert w.shape == (2, length)
-    wc = np.asarray(w[0] + 1j * w[1], dtype=np.complex128)
+    wc = np.asarray(cast("npt.ArrayLike", w[0] + 1j * w[1]), dtype=np.complex128)
     assert wc[0] == 0
     assert wc[-1] == 0
     assert np.count_nonzero(wc) > 0
@@ -66,12 +68,12 @@ def test_mixing() -> None:
     channels = {"xy": bosing.Channel(freq, sample_rate, length)}
     result = bosing.generate_waveforms(channels, shapes, schedule)
     w1 = result["xy"]
-    wc1 = np.asarray(w1[0] + 1j * w1[1], dtype=np.complex128)
+    wc1 = np.asarray(cast("npt.ArrayLike", w1[0] + 1j * w1[1]), dtype=np.complex128)
 
     channels = {"xy": bosing.Channel(0, sample_rate, length)}
     result = bosing.generate_waveforms(channels, shapes, schedule)
     w2 = result["xy"]
-    wc2 = np.asarray(w2[0] + 1j * w2[1], dtype=np.complex128)
+    wc2 = np.asarray(cast("npt.ArrayLike", w2[0] + 1j * w2[1]), dtype=np.complex128)
     wc2 = wc2 * np.exp(1j * (2 * np.pi * freq * np.arange(length) / sample_rate))
 
     assert np.allclose(wc1, wc2)


### PR DESCRIPTION
## Summary

- Split Rust and Python validation into dedicated CI jobs.
- Add cargo-deny checks for advisories, bans, licenses, and sources.
- Add pull request dependency review with severity and license policies.
- Schedule dependency audits and update lockfile/test typing compatibility.

## Testing

- CI configuration updated to run locked Rust and Python validation workflows.