### PR TITLE
reconfigure renovate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Decide whether the needed jobs succeeded or failed
-        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}
 
@@ -174,4 +174,4 @@ jobs:
         with:
           subject-path: "dist/*"
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -33,8 +33,6 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ steps.generate-token.outputs.token }}
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - name: Install Knope
         uses: knope-dev/action@19617851f9f13ab2f27a05989c55efb18aca3675 # v2.1.2
         with:

--- a/renovate.json
+++ b/renovate.json
@@ -1,12 +1,14 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "minimumReleaseAge": "14 days",
+  "lockFileMaintenance": {
+    "minimumReleaseAge": null
+  },
   "extends": [
     "config:best-practices",
     ":semanticCommitTypeAll(chore)",
     ":automergePatch",
     ":automergeStableNonMajor",
-    ":approveMajorUpdates",
     ":enablePreCommit",
     "helpers:pinGitHubActionDigestsToSemver",
     "customManagers:githubActionsVersions"
@@ -18,8 +20,10 @@
       "groupName": "PyO3 stack"
     },
     {
-      "description": "Require approval for Renovate-detected breaking updates",
-      "matchJsonata": ["isBreaking = true"],
+      "description": "Require approval for breaking updates except 0.x patch updates",
+      "matchJsonata": [
+        "isBreaking = true and (updateType != 'patch' or major != 0)"
+      ],
       "dependencyDashboardApproval": true
     }
   ]


### PR DESCRIPTION
## Summary

- Update GitHub Actions version annotations for CI and PyPI publishing.
- Remove the redundant Rust toolchain setup from release preparation.
- Allow lockfile maintenance immediately while requiring approval for breaking updates except 0.x patch updates.

## Testing

Not run (not requested)