### PR TITLE
chore(deps): update PyO3 to 0.29

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,16 +135,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
-name = "cc"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
-dependencies = [
- "find-msvc-tools",
- "shlex",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,12 +217,6 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
-name = "find-msvc-tools"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "float-cmp"
@@ -480,9 +464,9 @@ dependencies = [
 
 [[package]]
 name = "numpy"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778da78c64ddc928ebf5ad9df5edf0789410ff3bdbf3619aed51cd789a6af1e2"
+checksum = "6a5b15d63a5ff39e378daed0e1340d3a5964703ea9712eb09a0dc66fade996f4"
 dependencies = [
  "libc",
  "ndarray",
@@ -619,9 +603,9 @@ checksum = "1d8f70e07b9c3962945a74e59ca1c511bba65b6419468acc217c457d93f3c740"
 
 [[package]]
 name = "pyo3"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
  "anyhow",
  "hashbrown",
@@ -635,19 +619,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
- "python3-dll-a",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -655,9 +638,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -667,24 +650,14 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn 2.0.119",
-]
-
-[[package]]
-name = "python3-dll-a"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d80ba7540edb18890d444c5aa8e1f1f99b1bdf26fb26ae383135325f4a36042b"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -763,12 +736,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "shlex"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ pulp = "0.22.2"
 pyo3 = { version = "0.29.0", features = [
   "abi3-py310",
   "anyhow",
-  "generate-import-lib",
   "hashbrown",
 ] }
 rayon = "1.11.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,10 +32,10 @@ itertools = "0.14.0"
 mockall = "0.14.0"
 ndarray = { version = "0.17.1", features = ["rayon"] }
 num = "0.4.3"
-numpy = "0.28.0"
+numpy = "0.29.0"
 ordered-float = "5.1.0"
 pulp = "0.22.2"
-pyo3 = { version = "0.28.0", features = [
+pyo3 = { version = "0.29.0", features = [
   "abi3-py310",
   "anyhow",
   "generate-import-lib",

--- a/bosing-py/src/elements.rs
+++ b/bosing-py/src/elements.rs
@@ -487,7 +487,7 @@ impl Play {
         max_duration: Time,
         min_duration: Time,
         label: Option<Label>,
-    ) -> PyResult<(Self, Element)> {
+    ) -> PyResult<PyClassInitializer<Self>> {
         let variant = schedule::Play::new(
             channel_id.into(),
             shape_id.map(Into::into),
@@ -499,19 +499,17 @@ impl Play {
         .with_frequency(frequency.into())?
         .with_phase(phase.into())?
         .with_flexible(flexible);
-        Ok((
-            Self,
-            Self::build_element(
-                variant,
-                margin,
-                alignment,
-                phantom,
-                duration,
-                max_duration,
-                min_duration,
-                label,
-            )?,
-        ))
+        Ok(PyClassInitializer::from(Self::build_element(
+            variant,
+            margin,
+            alignment,
+            phantom,
+            duration,
+            max_duration,
+            min_duration,
+            label,
+        )?)
+        .add_subclass(Self))
     }
 
     #[getter]
@@ -623,21 +621,19 @@ impl ShiftPhase {
         max_duration: Time,
         min_duration: Time,
         label: Option<Label>,
-    ) -> PyResult<(Self, Element)> {
+    ) -> PyResult<PyClassInitializer<Self>> {
         let variant = schedule::ShiftPhase::new(channel_id.into(), phase.into())?;
-        Ok((
-            Self,
-            Self::build_element(
-                variant,
-                margin,
-                alignment,
-                phantom,
-                duration,
-                max_duration,
-                min_duration,
-                label,
-            )?,
-        ))
+        Ok(PyClassInitializer::from(Self::build_element(
+            variant,
+            margin,
+            alignment,
+            phantom,
+            duration,
+            max_duration,
+            min_duration,
+            label,
+        )?)
+        .add_subclass(Self))
     }
 
     #[getter]
@@ -722,21 +718,19 @@ impl SetPhase {
         max_duration: Time,
         min_duration: Time,
         label: Option<Label>,
-    ) -> PyResult<(Self, Element)> {
+    ) -> PyResult<PyClassInitializer<Self>> {
         let variant = schedule::SetPhase::new(channel_id.into(), phase.into())?;
-        Ok((
-            Self,
-            Self::build_element(
-                variant,
-                margin,
-                alignment,
-                phantom,
-                duration,
-                max_duration,
-                min_duration,
-                label,
-            )?,
-        ))
+        Ok(PyClassInitializer::from(Self::build_element(
+            variant,
+            margin,
+            alignment,
+            phantom,
+            duration,
+            max_duration,
+            min_duration,
+            label,
+        )?)
+        .add_subclass(Self))
     }
 
     #[getter]
@@ -809,21 +803,19 @@ impl ShiftFreq {
         max_duration: Time,
         min_duration: Time,
         label: Option<Label>,
-    ) -> PyResult<(Self, Element)> {
+    ) -> PyResult<PyClassInitializer<Self>> {
         let variant = schedule::ShiftFreq::new(channel_id.into(), frequency.into())?;
-        Ok((
-            Self,
-            Self::build_element(
-                variant,
-                margin,
-                alignment,
-                phantom,
-                duration,
-                max_duration,
-                min_duration,
-                label,
-            )?,
-        ))
+        Ok(PyClassInitializer::from(Self::build_element(
+            variant,
+            margin,
+            alignment,
+            phantom,
+            duration,
+            max_duration,
+            min_duration,
+            label,
+        )?)
+        .add_subclass(Self))
     }
 
     #[getter]
@@ -897,21 +889,19 @@ impl SetFreq {
         max_duration: Time,
         min_duration: Time,
         label: Option<Label>,
-    ) -> PyResult<(Self, Element)> {
+    ) -> PyResult<PyClassInitializer<Self>> {
         let variant = schedule::SetFreq::new(channel_id.into(), frequency.into())?;
-        Ok((
-            Self,
-            Self::build_element(
-                variant,
-                margin,
-                alignment,
-                phantom,
-                duration,
-                max_duration,
-                min_duration,
-                label,
-            )?,
-        ))
+        Ok(PyClassInitializer::from(Self::build_element(
+            variant,
+            margin,
+            alignment,
+            phantom,
+            duration,
+            max_duration,
+            min_duration,
+            label,
+        )?)
+        .add_subclass(Self))
     }
 
     #[getter]
@@ -987,21 +977,19 @@ impl SwapPhase {
         max_duration: Time,
         min_duration: Time,
         label: Option<Label>,
-    ) -> PyResult<(Self, Element)> {
+    ) -> PyResult<PyClassInitializer<Self>> {
         let variant = schedule::SwapPhase::new(channel_id1.into(), channel_id2.into());
-        Ok((
-            Self,
-            Self::build_element(
-                variant,
-                margin,
-                alignment,
-                phantom,
-                duration,
-                max_duration,
-                min_duration,
-                label,
-            )?,
-        ))
+        Ok(PyClassInitializer::from(Self::build_element(
+            variant,
+            margin,
+            alignment,
+            phantom,
+            duration,
+            max_duration,
+            min_duration,
+            label,
+        )?)
+        .add_subclass(Self))
     }
 
     #[getter]
@@ -1074,22 +1062,20 @@ impl Barrier {
         max_duration: Time,
         min_duration: Time,
         label: Option<Label>,
-    ) -> PyResult<(Self, Element)> {
+    ) -> PyResult<PyClassInitializer<Self>> {
         let channel_ids: Vec<_> = channel_ids.into_iter().map(Into::into).collect();
         let variant = schedule::Barrier::new(channel_ids);
-        Ok((
-            Self,
-            Self::build_element(
-                variant,
-                margin,
-                alignment,
-                phantom,
-                duration,
-                max_duration,
-                min_duration,
-                label,
-            )?,
-        ))
+        Ok(PyClassInitializer::from(Self::build_element(
+            variant,
+            margin,
+            alignment,
+            phantom,
+            duration,
+            max_duration,
+            min_duration,
+            label,
+        )?)
+        .add_subclass(Self))
     }
 
     #[getter]
@@ -1166,22 +1152,20 @@ impl Repeat {
         max_duration: Time,
         min_duration: Time,
         label: Option<Label>,
-    ) -> PyResult<(Self, Element)> {
+    ) -> PyResult<PyClassInitializer<Self>> {
         let rust_child = child.get().0.clone();
         let variant = schedule::Repeat::new(rust_child, count).with_spacing(spacing.into())?;
-        Ok((
-            Self { child },
-            Self::build_element(
-                variant,
-                margin,
-                alignment,
-                phantom,
-                duration,
-                max_duration,
-                min_duration,
-                label,
-            )?,
-        ))
+        Ok(PyClassInitializer::from(Self::build_element(
+            variant,
+            margin,
+            alignment,
+            phantom,
+            duration,
+            max_duration,
+            min_duration,
+            label,
+        )?)
+        .add_subclass(Self { child }))
     }
 
     #[getter]

--- a/bosing-py/src/elements/absolute.rs
+++ b/bosing-py/src/elements/absolute.rs
@@ -134,12 +134,10 @@ impl Absolute {
         let rust_base = &slf.cast::<Element>()?.get().0;
         let common = rust_base.common.clone();
         let variant = Self::variant(slf).clone().with_children(rust_children);
+        let base = Element(Arc::new(schedule::Element::new(common, variant)));
         Py::new(
             py,
-            (
-                Self { children },
-                Element(Arc::new(schedule::Element::new(common, variant))),
-            ),
+            PyClassInitializer::from(base).add_subclass(Self { children }),
         )
     }
 

--- a/bosing-py/src/elements/absolute.rs
+++ b/bosing-py/src/elements/absolute.rs
@@ -73,7 +73,7 @@ impl Absolute {
         max_duration: Time,
         min_duration: Time,
         label: Option<Label>,
-    ) -> PyResult<(Self, Element)> {
+    ) -> PyResult<PyClassInitializer<Self>> {
         let children: Vec<Entry> = children
             .into_iter()
             .map(|x| extract_absolute_entry(&x.into_bound(py)))
@@ -86,19 +86,17 @@ impl Absolute {
             })
             .collect::<PyResult<_>>()?;
         let variant = schedule::Absolute::new().with_children(rust_children);
-        Ok((
-            Self { children },
-            Self::build_element(
-                variant,
-                margin,
-                alignment,
-                phantom,
-                duration,
-                max_duration,
-                min_duration,
-                label,
-            )?,
-        ))
+        Ok(PyClassInitializer::from(Self::build_element(
+            variant,
+            margin,
+            alignment,
+            phantom,
+            duration,
+            max_duration,
+            min_duration,
+            label,
+        )?)
+        .add_subclass(Self { children }))
     }
 
     /// Create a new absolute schedule with different children.

--- a/bosing-py/src/elements/grid.rs
+++ b/bosing-py/src/elements/grid.rs
@@ -100,7 +100,7 @@ impl Grid {
         max_duration: Time,
         min_duration: Time,
         label: Option<Label>,
-    ) -> PyResult<(Self, Element)> {
+    ) -> PyResult<PyClassInitializer<Self>> {
         let children: Vec<_> = children
             .into_iter()
             .map(|x| extract_grid_entry(&x.into_bound(py)))
@@ -122,19 +122,17 @@ impl Grid {
         let variant = schedule::Grid::new()
             .with_children(rust_children)
             .with_columns(columns);
-        Ok((
-            Self { children },
-            Self::build_element(
-                variant,
-                margin,
-                alignment,
-                phantom,
-                duration,
-                max_duration,
-                min_duration,
-                label,
-            )?,
-        ))
+        Ok(PyClassInitializer::from(Self::build_element(
+            variant,
+            margin,
+            alignment,
+            phantom,
+            duration,
+            max_duration,
+            min_duration,
+            label,
+        )?)
+        .add_subclass(Self { children }))
     }
 
     /// Create a new grid schedule with different children.

--- a/bosing-py/src/elements/grid.rs
+++ b/bosing-py/src/elements/grid.rs
@@ -173,12 +173,10 @@ impl Grid {
         let rust_base = &slf.cast::<Element>()?.get().0;
         let common = rust_base.common.clone();
         let variant = Self::variant(slf).clone().with_children(rust_children);
+        let base = Element(Arc::new(schedule::Element::new(common, variant)));
         Py::new(
             py,
-            (
-                Self { children },
-                Element(Arc::new(schedule::Element::new(common, variant))),
-            ),
+            PyClassInitializer::from(base).add_subclass(Self { children }),
         )
     }
 

--- a/bosing-py/src/elements/stack.rs
+++ b/bosing-py/src/elements/stack.rs
@@ -71,7 +71,7 @@ impl Stack {
         max_duration: Time,
         min_duration: Time,
         label: Option<Label>,
-    ) -> PyResult<(Self, Element)> {
+    ) -> PyResult<PyClassInitializer<Self>> {
         let rust_children = children.iter().map(|x| x.get().0.clone()).collect();
         let variant = schedule::Stack::new().with_children(rust_children);
         let variant = if let Some(obj) = direction {
@@ -79,19 +79,17 @@ impl Stack {
         } else {
             variant
         };
-        Ok((
-            Self { children },
-            Self::build_element(
-                variant,
-                margin,
-                alignment,
-                phantom,
-                duration,
-                max_duration,
-                min_duration,
-                label,
-            )?,
-        ))
+        Ok(PyClassInitializer::from(Self::build_element(
+            variant,
+            margin,
+            alignment,
+            phantom,
+            duration,
+            max_duration,
+            min_duration,
+            label,
+        )?)
+        .add_subclass(Self { children }))
     }
 
     /// Create a new stack layout with different children.

--- a/bosing-py/src/elements/stack.rs
+++ b/bosing-py/src/elements/stack.rs
@@ -116,12 +116,10 @@ impl Stack {
         let rust_base = &slf.cast::<Element>()?.get().0;
         let common = rust_base.common.clone();
         let variant = Self::variant(slf).clone().with_children(rust_children);
+        let base = Element(Arc::new(schedule::Element::new(common, variant)));
         Py::new(
             py,
-            (
-                Self { children },
-                Element(Arc::new(schedule::Element::new(common, variant))),
-            ),
+            PyClassInitializer::from(base).add_subclass(Self { children }),
         )
     }
 

--- a/bosing-py/src/shapes.rs
+++ b/bosing-py/src/shapes.rs
@@ -41,8 +41,8 @@ pub struct Hann;
 #[pymethods]
 impl Hann {
     #[new]
-    const fn new() -> (Self, Shape) {
-        (Self, Shape)
+    fn new() -> PyClassInitializer<Self> {
+        PyClassInitializer::from(Shape).add_subclass(Self)
     }
 }
 
@@ -83,14 +83,11 @@ pub struct Interp {
 #[pymethods]
 impl Interp {
     #[new]
-    const fn new(knots: Vec<f64>, controls: Vec<f64>, degree: usize) -> (Self, Shape) {
-        (
-            Self {
-                knots,
-                controls,
-                degree,
-            },
-            Shape,
-        )
+    fn new(knots: Vec<f64>, controls: Vec<f64>, degree: usize) -> PyClassInitializer<Self> {
+        PyClassInitializer::from(Shape).add_subclass(Self {
+            knots,
+            controls,
+            degree,
+        })
     }
 }


### PR DESCRIPTION
## Summary

- update `pyo3` and `numpy` Rust crates to 0.29
- migrate Python subclass construction from tuple initialization to `PyClassInitializer`
- remove the deprecated no-op `generate-import-lib` feature

## Why

PyO3 0.29 deprecates tuple-based superclass initialization and switches Windows builds to raw-dylib linking. This keeps the bindings on the supported APIs and avoids carrying compatibility debt into future PyO3 releases.

## Impact

There are no intended Python API changes. The update improves compatibility with current Python/PyO3 toolchains while retaining the existing `abi3-py310` baseline.

## Validation

- `uv run task lint`
- `uv run task test` (7 Python tests and 35 Rust tests passed)
- `git diff --check`