### PR TITLE
fix Renovate Cargo dependency detection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,5 @@
+#:tombi toml-version = "v1.0.0"
+
 [package]
 name = "bosing"
 version.workspace = true
@@ -35,14 +37,11 @@ num = "0.4.3"
 numpy = "0.29.0"
 ordered-float = "5.1.0"
 pulp = "0.22.2"
-pyo3 = {
-  version = "0.29.0",
-  features = [
-    "abi3-py310",
-    "anyhow",
-    "hashbrown",
-  ]
-}
+pyo3 = { version = "0.29.0", features = [
+  "abi3-py310",
+  "anyhow",
+  "hashbrown",
+] }
 rayon = "1.11.0"
 test-case = "3.3.1"
 thiserror = "2.0.17"

--- a/bosing-py/Cargo.toml
+++ b/bosing-py/Cargo.toml
@@ -1,3 +1,5 @@
+#:tombi toml-version = "v1.0.0"
+
 [package]
 name = "bosing-py"
 version.workspace = true


### PR DESCRIPTION
## Summary

- pin both Cargo manifests to TOML 1.0 for Tombi
- restore the `pyo3` dependency declaration to TOML 1.0-compatible formatting

## Root cause

Tombi reformatted the `pyo3` inline table using TOML 1.1 multiline syntax. Renovate currently parses Cargo manifests as TOML 1.0, so it rejected the root manifest and stopped extracting the workspace's Rust dependencies. The TOML 1.1 syntax also exceeded the project's declared Rust 1.85 MSRV because Cargo only added TOML 1.1 support later.

## Impact

Renovate can parse the workspace dependencies again, and future Tombi formatting will preserve TOML 1.0 compatibility.

## Validation

- `tombi format --offline --check Cargo.toml bosing-py/Cargo.toml`
- `tombi lint --offline Cargo.toml bosing-py/Cargo.toml`
- `cargo metadata --no-deps --format-version 1`
- pre-commit hooks, including `tombi-format` and `cargo deny`
- `git diff --check`