### PR TITLE
Update Rust toolchain to 1.97

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.96"
+channel = "1.97"
 components = ["rustfmt", "clippy"]
 profile = "minimal"

--- a/src/pulse.rs
+++ b/src/pulse.rs
@@ -585,7 +585,7 @@ pub fn apply_iq_inplace(waveform: &mut ArrayViewMut2<'_, f64>, iq_matrix: ArrayV
 }
 
 pub fn apply_offset_inplace(waveform: &mut ArrayViewMut2<'_, f64>, offset: ArrayView1<'_, f64>) {
-    assert!(waveform.shape()[0] == offset.len());
+    assert_eq!(waveform.shape()[0], offset.len());
     azip!((mut row in waveform.axis_iter_mut(Axis(0)), &offset in &offset) row += offset);
 }
 

--- a/src/pulse/fir.rs
+++ b/src/pulse/fir.rs
@@ -14,7 +14,7 @@ impl WithSimd for ApplyFirInplace<'_, '_> {
     fn with_simd<S: Simd>(mut self, simd: S) -> Self::Output {
         let lanes = std::mem::size_of::<S::f64s>() / std::mem::size_of::<f64>();
         let buffer_len = align_ceil(self.taps.len(), lanes);
-        assert!(buffer_len % lanes == 0);
+        assert_eq!(buffer_len % lanes, 0);
         let taps_buffer = {
             let mut buffer = vec![0.0; buffer_len * 2];
             for (&t, b) in self.taps.iter().zip(buffer[..buffer_len].iter_mut().rev()) {

--- a/src/schedule/grid/helper.rs
+++ b/src/schedule/grid/helper.rs
@@ -40,7 +40,7 @@ impl<'a> Helper<'a> {
     }
 
     pub(super) fn new_with_column_sizes(columns: &'a [Length], column_sizes: Vec<Time>) -> Self {
-        assert!(columns.len() == column_sizes.len());
+        assert_eq!(columns.len(), column_sizes.len());
         Self {
             column_sizes,
             columns,


### PR DESCRIPTION
## Summary

- update the pinned Rust toolchain from 1.96 to 1.97
- adopt `assert_eq!` for equality assertions flagged by Clippy 1.97

## Why

Rust 1.97 introduces the `manual_assert_eq` Clippy lint. Because CI treats Clippy warnings as errors, the existing equality assertions would fail the Rust CI job after the toolchain update.

## Impact

The project now builds and lints cleanly with the Rust 1.97 toolchain. The assertion behavior is unchanged, while assertion failures provide clearer left/right diagnostics.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `git diff --check`
- commit hooks, including `cargo fmt` and `cargo deny`