### PR TITLE
feat: support schedule-based automatic waveform lengths

### DIFF
--- a/.changeset/automatic-waveform-length.md
+++ b/.changeset/automatic-waveform-length.md
@@ -1,0 +1,7 @@
+---
+default: minor
+---
+
+Allow `Channel.length` to default to `None` and derive waveform lengths from the logical schedule
+duration. Sampling bounds errors now report the required sample range and available waveform
+length.

--- a/bosing-py/src/wavegen.rs
+++ b/bosing-py/src/wavegen.rs
@@ -5,6 +5,7 @@ use bosing::{
         apply_offset_inplace, get_envelope,
     },
     quant,
+    schedule::Measure,
 };
 use hashbrown::HashMap;
 use ndarray::ArrayViewMut2;
@@ -41,7 +42,10 @@ use crate::{
 /// Args:
 ///     base_freq (float): Base frequency of the channel.
 ///     sample_rate (float): Sample rate of the channel.
-///     length (int): Length of the waveform.
+///     length (int | None): Length of the waveform. If ``None``, the length is
+///         determined from the logical duration of the schedule when generating
+///         waveforms. Channel delay or crosstalk can still move a pulse outside
+///         this time window. Defaults to ``None``.
 ///     delay (float): Delay of the channel. Defaults to ``0.0``.
 ///     align_level (int): Time axis alignment granularity. Defaults to ``-10``.
 ///     iq_matrix (array_like[2, 2] | None): IQ matrix of the channel. Defaults
@@ -61,7 +65,7 @@ use crate::{
 pub struct Channel {
     base_freq: Frequency,
     sample_rate: Frequency,
-    length: usize,
+    length: Option<usize>,
     delay: Time,
     align_level: i32,
     iq_matrix: Option<IqMatrix>,
@@ -78,7 +82,7 @@ impl Channel {
     #[pyo3(signature = (
         base_freq,
         sample_rate,
-        length,
+        length=None,
         *,
         delay=Time::ZERO,
         align_level=-10,
@@ -93,7 +97,7 @@ impl Channel {
     fn new(
         base_freq: Frequency,
         sample_rate: Frequency,
-        length: usize,
+        length: Option<usize>,
         delay: Time,
         align_level: i32,
         iq_matrix: Option<IqMatrix>,
@@ -472,7 +476,7 @@ fn build_envelopes_and_instructions(
                     .ceil_to_usize()
                     .ok_or_else(|| PyValueError::new_err("Invalid start index."))?;
 
-                if i_start >= channel.length {
+                if channel.length.is_some_and(|length| i_start >= length) {
                     return Err(PyValueError::new_err(
                         "The start index of a pulse is out of bounds, try adjusting channel delay, length or schedule.",
                     ));
@@ -599,6 +603,7 @@ pub fn generate_waveforms_with_states(
             ));
         }
     }
+    let schedule_duration = schedule.get().0.measure();
     let (pulse_lists, new_states) = build_pulse_lists(
         schedule,
         &channels,
@@ -608,7 +613,14 @@ pub fn generate_waveforms_with_states(
         allow_oversize,
         states.as_ref(),
     )?;
-    let waveforms = sample_waveform(py, &channels, pulse_lists, crosstalk, time_tolerance)?;
+    let waveforms = sample_waveform(
+        py,
+        &channels,
+        pulse_lists,
+        crosstalk,
+        time_tolerance,
+        schedule_duration,
+    )?;
     Ok((
         py.detach(|| {
             waveforms
@@ -750,17 +762,22 @@ fn sample_waveform(
     pulse_lists: ChannelPulses,
     crosstalk: Option<CrosstalkMatrix<'_>>,
     time_tolerance: Time,
+    schedule_duration: quant::Time,
 ) -> PyResult<ChannelWaveforms> {
     let waveforms: HashMap<_, _> = channels
         .iter()
         .map(|(n, c)| {
             let n_w = if c.is_real { 1 } else { 2 };
-            (
+            let length = match c.length {
+                Some(length) => length,
+                None => sample_count(schedule_duration, c.sample_rate.into())?,
+            };
+            Ok((
                 n.clone(),
-                PyArray2::zeros(py, (n_w, c.length), false).unbind(),
-            )
+                PyArray2::zeros(py, (n_w, length), false).unbind(),
+            ))
         })
-        .collect();
+        .collect::<PyResult<_>>()?;
     let mut sampler = Sampler::new(pulse_lists);
     for (n, c) in channels {
         // SAFETY: These arrays are just created.
@@ -779,6 +796,13 @@ fn sample_waveform(
     }
     py.detach(|| sampler.sample(time_tolerance.into()))?;
     Ok(waveforms)
+}
+
+fn sample_count(time: quant::Time, sample_rate: quant::Frequency) -> PyResult<usize> {
+    quant::AlignedIndex::new(time, sample_rate, 0)
+        .map_err(|e| PyValueError::new_err(format!("Invalid waveform length. Error: {e}")))?
+        .ceil_to_usize()
+        .ok_or_else(|| PyValueError::new_err("Invalid waveform length."))
 }
 
 fn post_process(w: &mut ArrayViewMut2<'_, f64>, c: &Channel) {

--- a/python/examples/flexible_length.py
+++ b/python/examples/flexible_length.py
@@ -13,9 +13,30 @@ schedule = Stack(
     ),
     margin=10e-9,
 )
-channels = {"xy": Channel(30e6, sample_rate, int(sample_rate * schedule.measure()))}
+channels = {"xy": Channel(30e6, sample_rate, length=None)}
 shapes = {"hann": Hann()}
 result = generate_waveforms(channels, shapes, schedule)
+
+# Automatic length covers the schedule's logical time window. These configurations
+# exceed that window, so the sampler reports how many samples are required.
+invalid_channels = {
+    "explicit length too short": {"xy": Channel(30e6, sample_rate, length=100)},
+    "delay moves pulse past the window": {
+        "xy": Channel(30e6, sample_rate, delay=20e-9)
+    },
+}
+
+
+def show_expected_error(label: str, invalid: dict[str, Channel]) -> None:
+    try:
+        _ = generate_waveforms(invalid, shapes, schedule)
+    except RuntimeError as error:
+        print(f"{label}:\n{error}")
+
+
+for label, invalid in invalid_channels.items():
+    show_expected_error(label, invalid)
+
 w = result["xy"]
 plt.plot(w[0], label="I")
 plt.plot(w[1], label="Q")

--- a/python/src/bosing/_bosing.pyi
+++ b/python/src/bosing/_bosing.pyi
@@ -47,7 +47,7 @@ class Channel:
         cls,
         base_freq: float,
         sample_rate: float,
-        length: int,
+        length: int | None = ...,
         *,
         delay: float = ...,
         align_level: int = ...,
@@ -63,7 +63,7 @@ class Channel:
     @property
     def sample_rate(self) -> float: ...
     @property
-    def length(self) -> int: ...
+    def length(self) -> int | None: ...
     @property
     def delay(self) -> float: ...
     @property

--- a/python/tests/test_basic.py
+++ b/python/tests/test_basic.py
@@ -2,6 +2,7 @@ from typing import cast
 
 import numpy as np
 import numpy.typing as npt
+import pytest
 from rich.pretty import pretty_repr
 
 import bosing
@@ -15,7 +16,9 @@ def _waveforms_from_instructions(
     result: dict[str, npt.NDArray[np.float64]] = {}
     for name, channel in channels.items():
         n_rows = 1 if channel.is_real else 2
-        waveform = np.zeros((n_rows, channel.length), dtype=np.float64)
+        length = channel.length
+        assert length is not None
+        waveform = np.zeros((n_rows, length), dtype=np.float64)
         dt = 1.0 / channel.sample_rate
         for inst in instructions[name]:
             env = envelopes[inst.env_id]
@@ -47,6 +50,97 @@ def test_basic() -> None:
     assert wc[0] == 0
     assert wc[-1] == 0
     assert np.count_nonzero(wc) > 0
+
+
+def test_auto_length() -> None:
+    sample_rate = 2e9
+    channels = {"xy": bosing.Channel(100e6, sample_rate, None)}
+    shapes = {"hann": bosing.Hann()}
+    schedule = bosing.Stack(duration=500e-9).with_children(
+        bosing.Play("xy", "hann", 0.1, 100e-9),
+    )
+
+    result = bosing.generate_waveforms(channels, shapes, schedule)
+    waveform = np.asarray(result["xy"], dtype=np.float64)
+
+    assert channels["xy"].length is None
+    assert waveform.shape == (2, 1000)
+    assert np.count_nonzero(waveform) > 0
+    assert np.count_nonzero(waveform[:, :800]) == 0
+    assert np.count_nonzero(waveform[:, 800:]) > 0
+
+
+def test_auto_length_uses_each_channel_sample_rate() -> None:
+    schedule = bosing.Barrier(duration=100e-9)
+    channels = {
+        "slow": bosing.Channel(0, 1e9),
+        "fast": bosing.Channel(0, 2e9),
+    }
+
+    result = bosing.generate_waveforms(channels, {}, schedule)
+
+    assert result["slow"].shape == (2, 100)
+    assert result["fast"].shape == (2, 200)
+
+
+def test_auto_length_does_not_expand_for_delay_and_crosstalk() -> None:
+    sample_rate = 1e9
+    channels = {
+        "source": bosing.Channel(0, sample_rate),
+        "target": bosing.Channel(0, sample_rate, delay=10e-9),
+    }
+    shapes = {"hann": bosing.Hann()}
+    schedule = bosing.Stack(
+        bosing.Play("source", "hann", 0.1, 100e-9),
+    )
+    crosstalk = (
+        np.array([[1.0, 0.0], [1.0, 0.0]]),
+        ["source", "target"],
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"Pulse sample range 10\.\.110 exceeds waveform length 100",
+    ):
+        _ = bosing.generate_waveforms(
+            channels,
+            shapes,
+            schedule,
+            crosstalk=crosstalk,
+        )
+
+
+def test_sampler_bounds_errors_include_required_and_available_lengths() -> None:
+    shapes = {"hann": bosing.Hann()}
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"Pulse sample range 0\.\.100 exceeds waveform length 50",
+    ):
+        _ = bosing.generate_waveforms(
+            {"xy": bosing.Channel(0, 1e9, 50)},
+            shapes,
+            bosing.Play("xy", "hann", 0.1, 100e-9),
+        )
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"Pulse start index 100 is outside waveform length 50",
+    ):
+        _ = bosing.generate_waveforms(
+            {"xy": bosing.Channel(0, 1e9, 50)},
+            shapes,
+            bosing.Absolute().with_children(
+                (100e-9, bosing.Play("xy", "hann", 0.1, 10e-9))
+            ),
+        )
+
+    with pytest.raises(RuntimeError, match="before the waveform start"):
+        _ = bosing.generate_waveforms(
+            {"xy": bosing.Channel(0, 1e9, 100, delay=-10e-9)},
+            shapes,
+            bosing.Play("xy", "hann", 0.1, 100e-9, alignment="start"),
+        )
 
 
 def test_mixing() -> None:
@@ -149,6 +243,7 @@ def test_repr() -> None:
     assert (
         repr(c) == "Channel(2000000000.0, 2000000000.0, 1000, fir=array([1., 2., 3.]))"
     )
+    assert repr(bosing.Channel(2e9, 2e9)) == "Channel(2000000000.0, 2000000000.0, None)"
 
 
 def test_generate_envelopes_and_instructions() -> None:
@@ -209,3 +304,18 @@ def test_generate_envelopes_and_instructions() -> None:
         states=states,
     )
     assert np.allclose(waveforms_from_inst["xy"], waveforms["xy"], atol=1e-12)
+
+
+def test_generate_envelopes_and_instructions_with_auto_length() -> None:
+    channels = {"xy": bosing.Channel(30e6, 2e9)}
+    shapes = {"hann": bosing.Hann()}
+    schedule = bosing.Play("xy", "hann", 0.3, 100e-9)
+
+    envelopes, instructions = bosing.generate_envelopes_and_instructions(
+        channels,
+        shapes,
+        schedule,
+    )
+
+    assert len(envelopes) == 1
+    assert len(instructions["xy"]) == 1

--- a/src/pulse.rs
+++ b/src/pulse.rs
@@ -502,6 +502,7 @@ where
     PL: IntoIterator<Item = (ListBin, L)>,
     L: IntoIterator<Item = (Time, PulseAmplitude)>,
 {
+    let waveform_length = waveform.shape()[1];
     for (bin, items) in list {
         let ListBin {
             envelope,
@@ -514,7 +515,7 @@ where
                 .expect("Reasonable align_level should not fail.");
             if i_frac_start.value() < 0.0 {
                 bail!(
-                    "The start time of a pulse is negative, try adjusting channel delay or schedule. start time: {time}",
+                    "Pulse start time {time:.6e} s is before the waveform start (0 s). Adjust channel delay or schedule.",
                     time = t_start.value()
                 );
             }
@@ -528,9 +529,9 @@ where
             let phase0 = global_freq * (i_start as f64 * dt - delay)
                 + local_freq * index_offset.value() * dt;
             let dphase = total_freq * dt;
-            if i_start >= waveform.shape()[1] {
+            if i_start >= waveform_length {
                 bail!(
-                    "The start index of a pulse is out of bounds, try adjusting channel delay, length or schedule. start index: {i_start}, start time: {time}",
+                    "Pulse start index {i_start} is outside waveform length {waveform_length} (start time: {time:.6e} s). Provide a larger explicit channel length or adjust channel delay or schedule.",
                     time = t_start.value()
                 );
             }
@@ -544,11 +545,14 @@ where
                     sample_rate,
                 );
                 let drag = drag * sample_rate.value();
-                if waveform.shape()[1] < envelope.len() {
+                let Some(i_end) = i_start.checked_add(envelope.len()) else {
+                    bail!("Pulse end index exceeds the supported integer range.");
+                };
+                if i_end > waveform_length {
                     #[expect(clippy::cast_precision_loss, reason = "Index is small.")]
                     let end_time = (envelope.len() as f64).mul_add(dt.value(), t_start.value());
                     bail!(
-                        "The pulse end time is out of bounds, try adjusting channel delay, length or schedule. end time: {end_time}"
+                        "Pulse sample range {i_start}..{i_end} exceeds waveform length {waveform_length} (end time: {end_time:.6e} s). Provide a larger explicit channel length or adjust channel delay or schedule."
                     );
                 }
                 mix_add_envelope(waveform, &envelope, amp, drag, phase0, dphase);
@@ -557,9 +561,12 @@ where
                 #[expect(clippy::cast_sign_loss, reason = "Plateau is positive.")]
                 #[expect(clippy::cast_possible_truncation, reason = "Index is small.")]
                 let i_plateau = (plateau.value() * sample_rate.value()).ceil() as usize;
-                if waveform.shape()[1] < i_plateau {
+                let Some(i_end) = i_start.checked_add(i_plateau) else {
+                    bail!("Pulse end index exceeds the supported integer range.");
+                };
+                if i_end > waveform_length {
                     bail!(
-                        "The pulse end time is out of bounds, try adjusting channel delay, length or schedule. end time: {end_time}",
+                        "Pulse sample range {i_start}..{i_end} exceeds waveform length {waveform_length} (end time: {end_time:.6e} s). Provide a larger explicit channel length or adjust channel delay or schedule.",
                         end_time = t_start.value() + plateau.value()
                     );
                 }


### PR DESCRIPTION
## Summary

- Allow `Channel.length` to default to `None`.
- Derive automatic waveform lengths from the schedule's logical duration and each channel's sample rate.
- Preserve existing behavior when an explicit waveform length is provided.
- Improve sampler bounds errors with the required sample range, available waveform length, and formatted timing information.
- Update Python stubs, tests, documentation examples, and release metadata.

## Behavior

Automatic length covers the logical schedule time window:

```python
channel = Channel(base_freq, sample_rate)
```

Channel delay, alignment, or crosstalk may still move a pulse outside that window. In that case, waveform generation reports the required sample range and users can provide a larger explicit length or adjust the schedule.

## Validation
```
uvx pre-commit run --all-files
uv run task test
uv run task lint
uv run task stubtest
uv run task makedocs
cargo build --workspace --locked
cargo test --workspace --locked
cargo clippy --workspace --all-targets --locked -- -D warnings
cargo fmt --all --check
```
All checks pass locally: 12 Python tests and 35 Rust tests.