### PR TITLE
fix knope changeset format

### DIFF
--- a/.changeset/automatic-waveform-length.md
+++ b/.changeset/automatic-waveform-length.md
@@ -2,6 +2,8 @@
 default: minor
 ---
 
+# Support schedule-based automatic waveform lengths
+
 Allow `Channel.length` to default to `None` and derive waveform lengths from the logical schedule
 duration. Sampling bounds errors now report the required sample range and available waveform
 length.

--- a/README.md
+++ b/README.md
@@ -95,14 +95,17 @@ uv run task test # run cargo test and pytest
 Releases are managed with knope.
 
 Contributors should add a `.changeset/*.md` file for user-visible changes. Each file starts
-with YAML front matter that declares the default bump level, followed by the release note text:
+with YAML front matter that declares the default bump level. The release note must start with a
+level-one heading containing a short summary; optional details go below the heading:
 
 ```md
 ---
 default: patch
 ---
 
-Brief description of the change.
+# Brief description of the change
+
+Optional details about the change.
 ```
 
 Maintainers do not cut releases manually. A push to `main` with pending `.changeset` entries


### PR DESCRIPTION
## Summary

- add the required level-one summary heading to the automatic waveform length changeset
- update the README changeset example to document the summary heading and optional details

## Why

Knope treats the first heading as the change summary. Without it, the wrapped first line was promoted to a changelog heading while the remaining text began mid-sentence, producing malformed release notes in #368.

## Impact

The next release preparation run will generate a complete changelog heading and preserve the full details paragraph.

## Validation

- `knope --validate` with Knope 0.22.4
- `knope --dry-run plan-release`
- `git diff --check`
- repository commit hooks