### PR TITLE
chore: group weekly Renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,9 @@
     ":automergeStableNonMajor",
     ":enablePreCommit",
     "helpers:pinGitHubActionDigestsToSemver",
-    "customManagers:githubActionsVersions"
+    "customManagers:githubActionsVersions",
+    "group:allNonMajor",
+    "schedule:weekly"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
## Summary

- run regular Renovate updates weekly
- group minor and patch dependency updates into one PR
- keep major updates and the existing PyO3 stack handling separate

## Validation

- `jq empty renovate.json`
- `git diff --check`
- pre-commit hooks passed during commit